### PR TITLE
Fix deprecated PHP each() function

### DIFF
--- a/lib/errorhandling.php
+++ b/lib/errorhandling.php
@@ -11,13 +11,13 @@ if (defined('E_DEPRECATED')) {
 #error_reporting (E_ALL);
 
 function set_magic_quotes(&$vars) {
-	if (is_array($vars)) {
-		reset($vars);
-		while (list($key,$val) = each($vars))
-			set_magic_quotes($vars[$key]);
-	}else{
-		$vars = addslashes($vars);
-	}
+        if (is_array($vars)) {
+                foreach ($vars as $key => $val) {
+                        set_magic_quotes($vars[$key]);
+                }
+        } else {
+                $vars = addslashes($vars);
+        }
 }
 
 


### PR DESCRIPTION
## Summary
- modernize deprecated usage of `each()` by replacing with `foreach`

## Testing
- `php -l lib/errorhandling.php`


------
https://chatgpt.com/codex/tasks/task_e_6848686ad1c08332a553f7cddb6890fe