### PR TITLE
Introduce prepared statements

### DIFF
--- a/lib/dbwrapper_mysqli_oos.php
+++ b/lib/dbwrapper_mysqli_oos.php
@@ -40,6 +40,71 @@ function db_query($sql, $die=true){
 	return $r;
 }
 
+function db_query_prepared($sql, $params = [], $types = '', $die = true)
+{
+    global $session, $dbinfo, $mysqli_resource;
+    $dbinfo['queriesthishit']++;
+    $starttime = getmicrotime();
+    $stmt = $mysqli_resource->prepare($sql);
+    if (!$stmt && $die === true) {
+        if (defined('IS_INSTALLER')) {
+            return false;
+        }
+        if ($session['user']['superuser'] & SU_DEVELOPER || 1) {
+            require_once('lib/show_backtrace.php');
+            die(
+                "<pre>" . HTMLEntities($sql, ENT_COMPAT, getsetting('charset', 'ISO-8859-1')) . "</pre>" .
+                db_error(LINK) .
+                show_backtrace()
+            );
+        }
+        die('A most bogus error has occurred.  I apologise, but the page you were trying to access is broken.  Please use your browser\'s back button and try again.');
+    }
+    if (!empty($params)) {
+        if ($types === '') {
+            foreach ($params as $p) {
+                if (is_int($p)) {
+                    $types .= 'i';
+                } elseif (is_float($p)) {
+                    $types .= 'd';
+                } else {
+                    $types .= 's';
+                }
+            }
+        }
+        $bind = [];
+        foreach ($params as $k => $p) {
+            $bind[$k] = &$params[$k];
+        }
+        array_unshift($bind, $types);
+        call_user_func_array([$stmt, 'bind_param'], $bind);
+    }
+    $r = $stmt->execute();
+    if (!$r && $die === true) {
+        if (defined('IS_INSTALLER')) {
+            return false;
+        }
+        if ($session['user']['superuser'] & SU_DEVELOPER || 1) {
+            require_once('lib/show_backtrace.php');
+            die(
+                "<pre>" . HTMLEntities($sql, ENT_COMPAT, getsetting('charset', 'ISO-8859-1')) . "</pre>" .
+                db_error(LINK) .
+                show_backtrace()
+            );
+        }
+        die('A most bogus error has occurred.  I apologise, but the page you were trying to access is broken.  Please use your browser\'s back button and try again.');
+    }
+    $result = $stmt->get_result();
+    unset($dbinfo['affected_rows']);
+    $dbinfo['affected_rows'] = $stmt->affected_rows;
+    if (!isset($dbinfo['querytime'])) {
+        $dbinfo['querytime'] = 0;
+    }
+    $endtime = getmicrotime();
+    $dbinfo['querytime'] += $endtime - $starttime;
+    return $result ?: $stmt;
+}
+
 //& at the start returns a reference to the data array.
 //since it's possible this array is large, we'll save ourselves
 //the overhead of duplicating the array, then destroying the old

--- a/lib/dbwrapper_mysqli_proc.php
+++ b/lib/dbwrapper_mysqli_proc.php
@@ -53,6 +53,75 @@ function db_query($sql, $die = true) {
 	return $r;
 }
 
+function db_query_prepared($sql, $params = [], $types = '', $die = true)
+{
+    global $session, $dbinfo, $mysqli_resource;
+    $dbinfo['queriesthishit']++;
+    $starttime = getmicrotime();
+    if (!$mysqli_resource) {
+        require_once('dbconnect.php');
+        db_connect($DB_HOST, $DB_USER, $DB_PASS, $DB_NAME);
+    }
+    $stmt = mysqli_prepare($mysqli_resource, $sql);
+    if (!$stmt && $die === true) {
+        if (defined('IS_INSTALLER')) {
+            return false;
+        }
+        if ($session['user']['superuser'] & SU_DEVELOPER || 1) {
+            require_once('lib/show_backtrace.php');
+            die(
+                "<pre>" . HTMLEntities($sql, ENT_COMPAT, getsetting('charset', 'ISO-8859-1')) . "</pre>" .
+                db_error(LINK) .
+                show_backtrace()
+            );
+        }
+        die('A most bogus error has occurred.  I apologise, but the page you were trying to access is broken.  Please use your browser\'s back button and try again.');
+    }
+    if (!empty($params)) {
+        if ($types === '') {
+            foreach ($params as $p) {
+                if (is_int($p)) {
+                    $types .= 'i';
+                } elseif (is_float($p)) {
+                    $types .= 'd';
+                } else {
+                    $types .= 's';
+                }
+            }
+        }
+        $bind = [];
+        $bind[] = $types;
+        foreach ($params as $k => $p) {
+            $bind[$k + 1] = &$params[$k];
+        }
+        call_user_func_array('mysqli_stmt_bind_param', array_merge([$stmt], $bind));
+    }
+    $r = mysqli_stmt_execute($stmt);
+    if (!$r && $die === true) {
+        if (defined('IS_INSTALLER')) {
+            return false;
+        }
+        if ($session['user']['superuser'] & SU_DEVELOPER || 1) {
+            require_once('lib/show_backtrace.php');
+            die(
+                "<pre>" . HTMLEntities($sql, ENT_COMPAT, getsetting('charset', 'ISO-8859-1')) . "</pre>" .
+                db_error(LINK) .
+                show_backtrace()
+            );
+        }
+        die('A most bogus error has occurred.  I apologise, but the page you were trying to access is broken.  Please use your browser\'s back button and try again.');
+    }
+    $result = mysqli_stmt_get_result($stmt);
+    unset($dbinfo['affected_rows']);
+    $dbinfo['affected_rows'] = mysqli_stmt_affected_rows($stmt);
+    if (!isset($dbinfo['querytime'])) {
+        $dbinfo['querytime'] = 0;
+    }
+    $endtime = getmicrotime();
+    $dbinfo['querytime'] += $endtime - $starttime;
+    return $result ?: $stmt;
+}
+
 //& at the start returns a reference to the data array.
 //since it's possible this array is large, we'll save ourselves
 //the overhead of duplicating the array, then destroying the old

--- a/lib/user/user_edit.php
+++ b/lib/user/user_edit.php
@@ -1,5 +1,5 @@
 <?php
-$result = db_query("SELECT * FROM " . db_prefix("accounts") . " WHERE acctid='$userid'");
+$result = db_query_prepared("SELECT * FROM " . db_prefix("accounts") . " WHERE acctid=?", [$userid]);
 $row = db_fetch_assoc($result);
 $petition=httpget("returnpetition");
 if ($petition != "")
@@ -81,8 +81,8 @@ if (httpget("subop")==""){
 			// Set up the defaults as well.
 			if (isset($x[1])) $data[$key] = $x[1];
 		}
-		$sql = "SELECT * FROM " . db_prefix("module_userprefs") ." WHERE modulename='$module' AND userid='$userid'";
-		$result = db_query($sql);
+$sql = "SELECT * FROM " . db_prefix("module_userprefs") ." WHERE modulename=? AND userid=?";
+$result = db_query_prepared($sql, [$module, $userid]);
 		while ($row = db_fetch_assoc($result)){
 			$data[$row['setting']] = $row['value'];
 		}

--- a/login.php
+++ b/login.php
@@ -33,8 +33,8 @@ if ($name!=""){
 		} else {
 			$password = md5(md5($password));
 		}
-		$sql = "SELECT * FROM " . db_prefix("accounts") . " WHERE login = '$name' AND password='$password' AND locked=0";
-		$result = db_query($sql);
+$sql = "SELECT * FROM " . db_prefix("accounts") . " WHERE login = ? AND password=? AND locked=0";
+$result = db_query_prepared($sql, [$name, $password]);
 		if (db_num_rows($result)==1){
 			$session['user']=db_fetch_assoc($result);
 			$companions = @unserialize($session['user']['companions']);
@@ -81,7 +81,10 @@ if ($name!=""){
 					exit();
 				}
 
-				db_query("UPDATE " . db_prefix("accounts") . " SET loggedin=".true.", laston='".date("Y-m-d H:i:s")."' WHERE acctid = ".$session['user']['acctid']);
+db_query_prepared(
+    "UPDATE " . db_prefix("accounts") . " SET loggedin=?, laston=? WHERE acctid = ?",
+    [true, date("Y-m-d H:i:s"), $session['user']['acctid']]
+);
 
 				$session['user']['loggedin']=true;
 				$location = $session['user']['location'];
@@ -102,20 +105,26 @@ if ($name!=""){
 			$session['message']=translate_inline("`4Error, your login was incorrect`0");
 			//now we'll log the failed attempt and begin to issue bans if
 			//there are too many, plus notify the admins.
-			$sql = "DELETE FROM " . db_prefix("faillog") . " WHERE date<'".date("Y-m-d H:i:s",strtotime("-".(getsetting("expirecontent",180)/4)." days"))."'";
-			checkban($name, true);
-			db_query($sql);
-			$sql = "SELECT acctid FROM " . db_prefix("accounts") . " WHERE login='$name'";
-			$result = db_query($sql);
+$sql = "DELETE FROM " . db_prefix("faillog") . " WHERE date < ?";
+checkban($name, true);
+db_query_prepared($sql, [date("Y-m-d H:i:s", strtotime("-" . (getsetting("expirecontent", 180)/4) . " days"))]);
+$sql = "SELECT acctid FROM " . db_prefix("accounts") . " WHERE login=?";
+$result = db_query_prepared($sql, [$name]);
 			if (db_num_rows($result)>0){
 				// just in case there manage to be multiple accounts on
 				// this name.
 				while ($row=db_fetch_assoc($result)){
 					$post = httpallpost();
-					$sql = "INSERT INTO " . db_prefix("faillog") . " VALUES (0,'".date("Y-m-d H:i:s")."','".addslashes(serialize($post))."','{$_SERVER['REMOTE_ADDR']}','{$row['acctid']}','{$_COOKIE['lgi']}')";
-					db_query($sql);
-					$sql = "SELECT " . db_prefix("faillog") . ".*," . db_prefix("accounts") . ".superuser,name,login FROM " . db_prefix("faillog") . " INNER JOIN " . db_prefix("accounts") . " ON " . db_prefix("accounts") . ".acctid=" . db_prefix("faillog") . ".acctid WHERE ip='{$_SERVER['REMOTE_ADDR']}' AND date>'".date("Y-m-d H:i:s",strtotime("-1 day"))."'";
-					$result2 = db_query($sql);
+$sql = "INSERT INTO " . db_prefix("faillog") . " VALUES (0, ?, ?, ?, ?, ?)";
+db_query_prepared($sql, [
+date("Y-m-d H:i:s"),
+addslashes(serialize($post)),
+$_SERVER['REMOTE_ADDR'],
+$row['acctid'],
+$_COOKIE['lgi']
+]);
+$sql = "SELECT " . db_prefix("faillog") . ".*," . db_prefix("accounts") . ".superuser,name,login FROM " . db_prefix("faillog") . " INNER JOIN " . db_prefix("accounts") . " ON " . db_prefix("accounts") . ".acctid=" . db_prefix("faillog") . ".acctid WHERE ip=? AND date> ?";
+$result2 = db_query_prepared($sql, [$_SERVER['REMOTE_ADDR'], date("Y-m-d H:i:s", strtotime("-1 day"))]);
 					$c=0;
 					$alert="";
 					$su=false;
@@ -127,20 +136,24 @@ if ($name!=""){
 					if ($c>=10){
 						// 5 failed attempts for superuser, 10 for regular user
 						$banmessage=translate_inline("Automatic System Ban: Too many failed login attempts.");
-						$sql = "INSERT INTO " . db_prefix("bans") . " VALUES ('{$_SERVER['REMOTE_ADDR']}','','".date("Y-m-d H:i:s",strtotime("+".($c*3)." hours"))."','$banmessage','System','0000-00-00 00:00:00')";
-						db_query($sql);
+$sql = "INSERT INTO " . db_prefix("bans") . " VALUES (?, '', ?, ?, 'System', '0000-00-00 00:00:00')";
+db_query_prepared($sql, [
+$_SERVER['REMOTE_ADDR'],
+date("Y-m-d H:i:s", strtotime("+" . ($c*3) . " hours")),
+$banmessage
+]);
 						if ($su){
 							// send a system message to admins regarding
 							// this failed attempt if it includes superusers.
-							$sql = "SELECT acctid FROM " . db_prefix("accounts") ." WHERE (superuser&".SU_EDIT_USERS.")";
-							$result2 = db_query($sql);
+$sql = "SELECT acctid FROM " . db_prefix("accounts") ." WHERE (superuser&".SU_EDIT_USERS.")";
+$result2 = db_query_prepared($sql);
 							$subj = translate_mail(array("`#%s failed to log in too many times!",$_SERVER['REMOTE_ADDR']),0);
 							$number=db_num_rows($result2);
 							for ($i=0;$i<$number;$i++){
 								$row2 = db_fetch_assoc($result2);
 								//delete old messages that
-								$sql = "DELETE FROM " . db_prefix("mail") . " WHERE msgto={$row2['acctid']} AND msgfrom=0 AND subject = '".serialize($subj)."' AND seen=0";
-								db_query($sql);
+$sql = "DELETE FROM " . db_prefix("mail") . " WHERE msgto=? AND msgfrom=0 AND subject = ? AND seen=0";
+db_query_prepared($sql, [$row2['acctid'], serialize($subj)]);
 								if (db_affected_rows()>0) $noemail = true; else $noemail = false;
 								$msg = translate_mail(array("This message is generated as a result of one or more of the accounts having been a superuser account.  Log Follows:`n`n%s",$alert),0);
 								systemmail($row2['acctid'],$subj,$msg,0,$noemail);
@@ -158,10 +171,10 @@ if ($name!=""){
 		if ($location == $iname) {
 			$session['user']['restorepage']="inn.php?op=strolldown";
 		} else {
-			$session['user']['restorepage']="news.php";
-		}
-		$sql = "UPDATE " . db_prefix("accounts") . " SET loggedin=0,restorepage='{$session['user']['restorepage']}' WHERE acctid = ".$session['user']['acctid'];
-		db_query($sql);
+$session['user']['restorepage']="news.php";
+}
+$sql = "UPDATE " . db_prefix("accounts") . " SET loggedin=0,restorepage=? WHERE acctid = ?";
+db_query_prepared($sql, [$session['user']['restorepage'], $session['user']['acctid']]);
 		invalidatedatacache("charlisthomepage");
 		invalidatedatacache("list.php-warsonline");
 

--- a/modules/switch.php
+++ b/modules/switch.php
@@ -81,11 +81,12 @@ function switch_run()
             $post = httpallpost();
             $post['password'] = md5(md5($post['password']));
             $post['login'] = filter_var($post['login'], FILTER_SANITIZE_STRING);
-            $sql = db_query(
+            $sql = db_query_prepared(
                 "SELECT acctid, name, uniqueid, lastip
                 FROM $accounts
-                WHERE password = '{$post['password']}'
-                AND login = '{$post['login']}'"
+                WHERE password = ?
+                AND login = ?",
+                [$post['password'], $post['login']]
             );
             if (db_num_rows($sql) == 0) {
                 addnav('Go back', 'runmodule.php?module=switch&op=add');
@@ -147,9 +148,9 @@ function switch_run()
                 debuglog('tried to switch into an account they do not have access to!');
                 break;
             }
-            $sql = db_query("UPDATE $accounts SET loggedin = 0 WHERE acctid = '{$session['user']['acctid']}'");
-            $sql = db_query("UPDATE $accounts SET loggedin = 1 WHERE acctid = '$id'");
-            $sql = db_query("SELECT * FROM $accounts WHERE acctid = '$id'");
+            $sql = db_query_prepared("UPDATE $accounts SET loggedin = 0 WHERE acctid = ?", [$session['user']['acctid']]);
+            $sql = db_query_prepared("UPDATE $accounts SET loggedin = 1 WHERE acctid = ?", [$id]);
+            $sql = db_query_prepared("SELECT * FROM $accounts WHERE acctid = ?", [$id]);
             $session['user'] = db_fetch_assoc($sql);
             $session['loggedin'] = true;
             $session['laston'] = date('Y-m-d H:i:s');
@@ -176,10 +177,11 @@ function switch_run()
                 );
                 foreach ($allAccounts as $acctid) {
                     debug($acctid);
-                    $sql = db_query(
+                    $sql = db_query_prepared(
                         "SELECT name
                         FROM $accounts
-                        WHERE acctid = '$acctid'"
+                        WHERE acctid = ?",
+                        [$acctid]
                     );
                     $row = db_fetch_assoc($sql);
                     output(


### PR DESCRIPTION
## Summary
- add `db_query_prepared` helper to mysqli wrappers
- use prepared statements for login and user editing
- refactor `switch` module queries to use new helper

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68487e987f148332824e2712ea71341f