### PR TITLE
Refactor deprecated each() loops

### DIFF
--- a/lib/dbwrapper_mysqli_oos.php
+++ b/lib/dbwrapper_mysqli_oos.php
@@ -80,12 +80,16 @@ function db_error(){
 }
 
 function db_fetch_assoc(&$result){
-	if (is_array($result)){
-		//cached data
-		if (list($key,$val)=each($result))
-			return $val;
-		else
-			return false;
+       if (is_array($result)){
+               //cached data
+               $key = key($result);
+               if ($key !== null){
+                       $val = current($result);
+                       next($result);
+                       return $val;
+               } else {
+                       return false;
+               }
 	}else{
 		//$fname = DBTYPE."_fetch_assoc";
 		//$r = $fname($result);

--- a/lib/dbwrapper_sqlite.php
+++ b/lib/dbwrapper_sqlite.php
@@ -116,17 +116,18 @@ function db_error(): string
  * Return an associative array of recent statement, or checks the cache.
  * @return array
  */
-function db_fetch_assoc(array $result)
+function db_fetch_assoc(&$result)
 {
     if (is_array($result)) {
-        if (list($key, $val) = each($result)) {
+        $key = key($result);
+        if ($key !== null) {
+            $val = current($result);
+            next($result);
             return $val;
-        }
-        else {
+        } else {
             return false;
         }
-    }
-    else {
+    } else {
         return $result->fetchArray(SQLITE3_ASSOC);
     }
 }

--- a/lib/errorhandling.php
+++ b/lib/errorhandling.php
@@ -11,13 +11,13 @@ if (defined('E_DEPRECATED')) {
 #error_reporting (E_ALL);
 
 function set_magic_quotes(&$vars) {
-	if (is_array($vars)) {
-		reset($vars);
-		while (list($key,$val) = each($vars))
-			set_magic_quotes($vars[$key]);
-	}else{
-		$vars = addslashes($vars);
-	}
+       if (is_array($vars)) {
+               foreach ($vars as $key => $val) {
+                       set_magic_quotes($vars[$key]);
+               }
+       } else {
+               $vars = addslashes($vars);
+       }
 }
 
 

--- a/lib/installer/installer_stage_9.php
+++ b/lib/installer/installer_stage_9.php
@@ -10,7 +10,6 @@ output("`n`@Table Synchronization Logs:`n");
 rawoutput("<div style='width: 100%; height: 150px; max-height: 150px; overflow: auto;'>");
 $descriptors = descriptors($DB_PREFIX);
 require_once("lib/tabledescriptor.php");
-reset($descriptors);
 foreach ($descriptors as $tableName => $descriptor) {
 	output("`3Synchronizing table `#$tableName`3..`n");
 	synctable($tableName, $descriptor, true);
@@ -21,14 +20,12 @@ rawoutput("</div>");
 output("`n`2The tables now have new fields and columns added, I'm going to begin importing data now.`n");
 rawoutput("<div style='width: 100%; height: 150px; max-height: 150px; overflow: auto;'>");
 $doSQL = false;
-reset($sql_upgrade_statements);
 foreach ($sql_upgrade_statements as $key => $val) {
 	if ($doSQL) {
 		output("`3Version `#%s`3: %s SQL statements...`n", $key, count($val));
 		if (count($val) > 0) {
-			output("`^Doing: `6");
-			reset($val);
-			$count = 0;
+                       output("`^Doing: `6");
+                       $count = 0;
 			foreach ($val as $id => $sql) {
 				$onlyupgrade = 0;
 				if (substr($sql, 0, 2) == '1|') {
@@ -79,9 +76,8 @@ if (!getSession('skipmodules')) {
   output("`n`2Now I'll install and configure your modules.");
   rawoutput("<div style='width: 100%; height: 150px; max-height: 150px; overflow: auto;'>");
   foreach($session['moduleoperations'] as $modName => $val) {
-	  $ops = explode(',', $val);
-	  reset($ops);
-		foreach ($ops as $trash => $op) {
+      $ops = explode(',', $val);
+                foreach ($ops as $trash => $op) {
 		  switch ($op) {
 			  case "uninstall":
 				  output("`3Uninstalling `#$modName`3: ");
@@ -122,7 +118,6 @@ if (!getSession('skipmodules')) {
 }
 output("`n`2Finally, I'll clean up old data.`n");
 rawoutput("<div style='width: 100%; height: 150px; max-height: 150px; overflow: auto;'>");
-reset($descriptors);
 foreach ($descriptors as $tableName => $descriptor) {
 	output("`3Cleaning up `#$tableName`3...`n");
 	synctable($tableName, $descriptor);


### PR DESCRIPTION
## Summary
- replace `each()` in set_magic_quotes() with `foreach`
- iterate cached results using `key()`/`current()`/`next()` for sqlite and mysqli
- remove extra `reset()` calls in installer

## Testing
- `php -l lib/errorhandling.php`
- `php -l lib/dbwrapper_sqlite.php`
- `php -l lib/dbwrapper_mysqli_oos.php`
- `php -l lib/installer/installer_stage_9.php`


------
https://chatgpt.com/codex/tasks/task_e_68487e8fa2d88332aaa8df7db705f6e3