### PR TITLE
Remove magic quotes handling and add explicit escaping

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,9 @@ sudo chown -R www-data:www-data ./cache/
 
 # Navigate to /installer.php in your browser. Be sure to include the name of your cache folder during installation.
 ```
+
+## Security Notes
+Legacy versions relied on PHP's deprecated *magic quotes* feature to escape user
+input. This project no longer enables magic quotes. When writing new code or
+modules, use `db_escape()` or parameterized queries to sanitize all input before
+executing database statements.

--- a/lib/dbwrapper.php
+++ b/lib/dbwrapper.php
@@ -18,3 +18,21 @@ define('DBTYPE', 'mysqli_proc');
 $dbinfo['queriesthishit'] = 0;
 
 require_once('lib/dbwrapper_' . DBTYPE . '.php');
+
+function db_escape(string $string): string
+{
+    switch (DBTYPE) {
+        case 'mysqli_proc':
+        case 'mysqli_oos':
+            global $mysqli_resource;
+            if (!$mysqli_resource) {
+                require_once('dbconnect.php');
+                db_connect($DB_HOST, $DB_USER, $DB_PASS, $DB_NAME);
+            }
+            return mysqli_real_escape_string($mysqli_resource, $string);
+        case 'mysqli_sqlite':
+            return SQLite3::escapeString($string);
+        default:
+            return addslashes($string);
+    }
+}

--- a/lib/errorhandling.php
+++ b/lib/errorhandling.php
@@ -10,25 +10,3 @@ if (defined('E_DEPRECATED')) {
 }
 #error_reporting (E_ALL);
 
-function set_magic_quotes(&$vars) {
-	if (is_array($vars)) {
-		reset($vars);
-		while (list($key,$val) = each($vars))
-			set_magic_quotes($vars[$key]);
-	}else{
-		$vars = addslashes($vars);
-	}
-}
-
-
-//do some cleanup here to make sure magic_quotes_gpc is ON
-if (function_exists("get_magic_quotes_runtime") && function_exists("get_magic_quotes_gpc")) {
-	set_magic_quotes($_GET);
-	set_magic_quotes($_POST);
-	set_magic_quotes($_SESSION);
-	set_magic_quotes($_COOKIE);
-	set_magic_quotes($HTTP_GET_VARS);
-	set_magic_quotes($HTTP_POST_VARS);
-	set_magic_quotes($HTTP_COOKIE_VARS);
-	ini_set("magic_quotes_gpc",1);
-}

--- a/login.php
+++ b/login.php
@@ -33,8 +33,10 @@ if ($name!=""){
 		} else {
 			$password = md5(md5($password));
 		}
-		$sql = "SELECT * FROM " . db_prefix("accounts") . " WHERE login = '$name' AND password='$password' AND locked=0";
-		$result = db_query($sql);
+                $name = db_escape($name);
+                $password = db_escape($password);
+                $sql = "SELECT * FROM " . db_prefix("accounts") . " WHERE login = '$name' AND password='$password' AND locked=0";
+                $result = db_query($sql);
 		if (db_num_rows($result)==1){
 			$session['user']=db_fetch_assoc($result);
 			$companions = @unserialize($session['user']['companions']);
@@ -105,7 +107,8 @@ if ($name!=""){
 			$sql = "DELETE FROM " . db_prefix("faillog") . " WHERE date<'".date("Y-m-d H:i:s",strtotime("-".(getsetting("expirecontent",180)/4)." days"))."'";
 			checkban($name, true);
 			db_query($sql);
-			$sql = "SELECT acctid FROM " . db_prefix("accounts") . " WHERE login='$name'";
+                        $escname = db_escape($name);
+                        $sql = "SELECT acctid FROM " . db_prefix("accounts") . " WHERE login='$escname'";
 			$result = db_query($sql);
 			if (db_num_rows($result)>0){
 				// just in case there manage to be multiple accounts on


### PR DESCRIPTION
## Summary
- drop deprecated magic quotes logic
- provide `db_escape` helper for escaping values
- escape login credentials before DB queries
- note removal of magic quotes in docs

## Testing
- `php -l lib/errorhandling.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68487e8a9b2083328570a0e399f54022