### PR TITLE
Use PHP password_hash()

### DIFF
--- a/create.php
+++ b/create.php
@@ -26,14 +26,10 @@ if ($op=="val"){
 		$sql = "UPDATE " . db_prefix("accounts") . " SET emailvalidation='' WHERE emailvalidation='$id';";
 		db_query($sql);
 		output("`#`cYour email has been validated.  You may now log in.`c`0");
-		rawoutput("<form action='login.php' method='POST'>");
-		rawoutput("<input name='name' value=\"{$row['login']}\" type='hidden'>");
-		rawoutput("<input name='password' value=\"!md52!{$row['password']}\" type='hidden'>");
-		rawoutput("<input name='force' value='1' type='hidden'>");
-		output("Your email has been validated, your login name is `^%s`0.`n`n",
-				$row['login']);
-		$click = translate_inline("Click here to log in");
-		rawoutput("<input type='submit' class='button' value='$click'></form>");
+               output("Your email has been validated, your login name is `^%s`0.`n`n",
+                               $row['login']);
+               $click = translate_inline("Click here to log in");
+               rawoutput("<a href='login.php'>$click</a>");
 		output_notl("`n");
 		if ($trash > 0) {
 			output("`^Characters that have never been logged into will be deleted after %s day(s) of no activity.`n`0", $trash);
@@ -125,15 +121,11 @@ if (getsetting("allowcreation",1)==0){
 				}
 			}
 
-			$passlen = (int)httppost("passlen");
-			if (substr($pass1, 0, 5) != "!md5!" &&
-					substr($pass1, 0, 6) != "!md52!") {
-				$passlen = strlen($pass1);
-			}
-			if ($passlen<=3){
-					$msg.=translate_inline("Your password must be at least 4 characters long.`n");
-				$blockaccount=true;
-			}
+                       $passlen = strlen($pass1);
+                       if ($passlen <= 3){
+                                       $msg.=translate_inline("Your password must be at least 4 characters long.`n");
+                               $blockaccount=true;
+                       }
 			if ($pass1!=$pass2){
 				$msg.=translate_inline("Your passwords do not match.`n");
 				$blockaccount=true;
@@ -182,12 +174,7 @@ if (getsetting("allowcreation",1)==0){
 					}else{
 						$referer=0;
 					}
-					$dbpass = "";
-					if (substr($pass1, 0, 5) == "!md5!") {
-						$dbpass = md5(substr($pass1, 5));
-					} else {
-						$dbpass = md5(md5($pass1));
-					}
+                                       $dbpass = password_hash($pass1, PASSWORD_DEFAULT);
 					$sql = "INSERT INTO " . db_prefix("accounts") . "
 						(name, superuser, title, password, sex, login, laston, uniqueid, lastip, gold, emailaddress, emailvalidation, referer, regdate)
 						VALUES
@@ -243,30 +230,9 @@ if (getsetting("allowcreation",1)==0){
 		$refer=httpget('r');
 		if ($refer) $refer = "&r=".htmlentities($refer, ENT_COMPAT, getsetting("charset", "ISO-8859-1"));
 
-		rawoutput("<script language='JavaScript' src='lib/md5.js'></script>");
-		rawoutput("<script language='JavaScript'>
-		<!--
-		function md5pass(){
-			// encode passwords
-			var plen = document.getElementById('passlen');
-			var pass1 = document.getElementById('pass1');
-			plen.value = pass1.value.length;
-
-			if(pass1.value.substring(0, 5) != '!md5!') {
-				pass1.value = '!md5!'+hex_md5(pass1.value);
-			}
-			var pass2 = document.getElementById('pass2');
-			if(pass2.value.substring(0, 5) != '!md5!') {
-				pass2.value = '!md5!'+hex_md5(pass2.value);
-			}
-
-		}
-		//-->
-		</script>");
-		rawoutput("<form action=\"create.php?op=create$refer\" method='POST' onSubmit=\"md5pass();\">");
+		rawoutput("<form action=\"create.php?op=create$refer\" method='POST' >");
 		// this is the first thing a new player will se, so let's make it look
 		// better
-		rawoutput("<input type='hidden' name='passlen' id='passlen' value='0'>");
 		rawoutput("<table><tr valign='top'><td>");
 		output("How will you be known to this world? ");
 		rawoutput("</td><td><input name='name'></td></tr><tr valign='top'><td>");

--- a/home.php
+++ b/home.php
@@ -92,22 +92,9 @@ if ($onlinecount<getsetting("maxonline",0) || getsetting("maxonline",0)==0){
 	}
 	if (isset($session['message']) && $session['message']>"")
 		output_notl("`b`\$%s`b`n", $session['message'],true);
-	rawoutput("<script language='JavaScript' src='lib/md5.js'></script>");
-	rawoutput("<script language='JavaScript'>
-	<!--
-	function md5pass(){
-		//encode passwords before submission to protect them even from network sniffing attacks.
-		var passbox = document.getElementById('password');
-		if (passbox.value.substring(0, 5) != '!md5!') {
-			passbox.value = '!md5!' + hex_md5(passbox.value);
-		}
-	}
-	//-->
-	</script>");
-	$uname = translate_inline("<u>U</u>sername");
 	$pass = translate_inline("<u>P</u>assword");
 	$butt = translate_inline("Log in");
-	rawoutput("<form action='login.php' method='POST' onSubmit=\"md5pass();\">".templatereplace("login",array("username"=>$uname,"password"=>$pass,"button"=>$butt))."</form>");
+	rawoutput("<form action='login.php' method='POST' >".templatereplace("login",array("username"=>$uname,"password"=>$pass,"button"=>$butt))."</form>");
 	output_notl("`c");
 	addnav("","login.php");
 } else {

--- a/lib/installer/installer_stage_0.php
+++ b/lib/installer/installer_stage_0.php
@@ -14,12 +14,12 @@ if (DB_CHOSEN && file_exists('dbconnect.php')) {
 		$needsauthentication = false;
 	}
 	if (httppost("username")>""){
-		debug(md5(md5(stripslashes(httppost("password")))), true);
+       debug(password_hash(stripslashes(httppost("password")), PASSWORD_DEFAULT), true);
 		$version = getsetting("installer_version","-1");
 		$accountsPrefix = db_prefix('accounts');
 		$userName = mysqli_real_escape_string($mysqli_resource, httppost('username'));
 		$password = mysqli_real_escape_string($mysqli_resource, httppost('password'));
-		$newPassworc = md5(md5(stripslashes(httppost('password'))));
+       $newPassworc = password_hash(stripslashes(httppost('password')), PASSWORD_DEFAULT);
 		$megaUser = SU_MEGAUSER;
 		if ($version == "-1")
 			$sql = "SELECT * FROM $accountsPrefix

--- a/lib/installer/installer_stage_10.php
+++ b/lib/installer/installer_stage_10.php
@@ -31,7 +31,7 @@ if (db_num_rows($result) == 0) {
 			SU_POST_MOTD | SU_MODERATE_CLANS | SU_EDIT_RIDDLES |
 			SU_MANAGE_MODULES | SU_AUDIT_MODERATION | SU_RAW_SQL |
 			SU_VIEW_SOURCE | SU_NEVER_EXPIRE;
-			$pass = md5(md5(stripslashes(httppost('pass1'))));
+                        $pass = password_hash(stripslashes(httppost('pass1')), PASSWORD_DEFAULT);
 			db_query(
 				"DELETE FROM $accountsPrefix WHERE login = '$name'"
 			);

--- a/lib/user/user_save.php
+++ b/lib/user/user_save.php
@@ -13,12 +13,12 @@ foreach ($post as $key => $val) {
 	if (isset($userinfo[$key])){
 		if ($key=="newpassword" ){
 			if ($val>"") {
-				$sql.="password=\"".md5(md5($val))."\",";
+                               $sql.="password=\"".addslashes(password_hash($val, PASSWORD_DEFAULT))."\",";
 				$updates++;
 				output("Password value has been updated.`n");
 				debuglog($session['user']['name']."`0 changed password to $val",$userid);
 				if ($session['user']['acctid']==$userid) {
-					$session['user']['password']=md5(md5($val));
+                                       $session['user']['password']=password_hash($val, PASSWORD_DEFAULT);
 				}
 			}
 		}elseif ($key=="superuser"){

--- a/login.php
+++ b/login.php
@@ -19,26 +19,52 @@ if ($name!=""){
 	if ($session['loggedin']){
 		redirect("badnav.php");
 	}else{
-		$password = httppost('password');
-		$password = stripslashes($password);
-		if (substr($password, 0, 5) == "!md5!") {
-			$password = md5(substr($password, 5));
-		} elseif (substr($password, 0, 6) == "!md52!") {// && strlen($password) == 38) {
-			$force = httppost('force');
-			if ($force) {
-				$password = addslashes(substr($password, 6));
-			} else {
-				$password='no hax0rs for j00!';
-			}
-		} else {
-			$password = md5(md5($password));
-		}
-		$sql = "SELECT * FROM " . db_prefix("accounts") . " WHERE login = '$name' AND password='$password' AND locked=0";
-		$result = db_query($sql);
-		if (db_num_rows($result)==1){
-			$session['user']=db_fetch_assoc($result);
-			$companions = @unserialize($session['user']['companions']);
-			if (!is_array($companions)) $companions = array();
+               $rawpass = httppost('password');
+               $rawpass = stripslashes($rawpass);
+               $force = httppost('force');
+
+               // Preserve compatibility with legacy hashed submissions
+               $md5pass = md5(md5($rawpass));
+               if (substr($rawpass, 0, 5) == "!md5!") {
+                       $md5pass = md5(substr($rawpass, 5));
+               } elseif (substr($rawpass, 0, 6) == "!md52!" && $force) {
+                       $md5pass = addslashes(substr($rawpass, 6));
+               }
+
+               $sql = "SELECT * FROM " . db_prefix("accounts") . " WHERE login = '$name' AND locked=0";
+               $result = db_query($sql);
+               if (db_num_rows($result)==1){
+                       $session['user']=db_fetch_assoc($result);
+                       $stored = $session['user']['password'];
+                       $valid = false;
+                       if (substr($stored,0,1)==='$') {
+                               // new style hash
+                               if (substr($rawpass,0,5) !== '!md5!' && substr($rawpass,0,6) !== '!md52!') {
+                                       if (password_verify($rawpass, $stored)) {
+                                               $valid = true;
+                                               if (password_needs_rehash($stored, PASSWORD_DEFAULT)) {
+                                                       $newhash = password_hash($rawpass, PASSWORD_DEFAULT);
+                                                       db_query("UPDATE " . db_prefix("accounts") . " SET password='".addslashes($newhash)."' WHERE acctid=".$session['user']['acctid']);
+                                                       $session['user']['password'] = $newhash;
+                                               }
+                                       }
+                               }
+                       } else {
+                               // legacy md5 hash
+                               if ($md5pass == $stored) {
+                                       $valid = true;
+                                       if (substr($rawpass,0,5) !== '!md5!' && substr($rawpass,0,6) !== '!md52!') {
+                                               $newhash = password_hash($rawpass, PASSWORD_DEFAULT);
+                                               db_query("UPDATE " . db_prefix("accounts") . " SET password='".addslashes($newhash)."' WHERE acctid=".$session['user']['acctid']);
+                                               $session['user']['password'] = $newhash;
+                                       }
+                               }
+                       }
+                       if (!$valid) {
+                               $session['user'] = array();
+                       }
+                       $companions = @unserialize($session['user']['companions']);
+                       if (!is_array($companions)) $companions = array();
 			$baseaccount = $session['user'];
 			checkban($session['user']['login'], true); 
 			modulehook("check-login");

--- a/modules/settings.php
+++ b/modules/settings.php
@@ -142,9 +142,18 @@ function settings_run()
                 unset($post['return']);
             }
             //Fix template changes.
-            if (md5(md5($post['oldpass'])) == $session['user']['password'] && $post['newpass'] != '') {
+            $stored = $session['user']['password'];
+            $validOld = false;
+            if (substr($stored, 0, 1) === '$') {
+                $validOld = password_verify($post['oldpass'], $stored);
+            } else {
+                if (md5(md5($post['oldpass'])) == $stored) {
+                    $validOld = true;
+                }
+            }
+            if ($validOld && $post['newpass'] != '') {
                 require_once('lib/systemmail.php');
-                $newPass = md5(md5($post['newpass']));
+                $newPass = password_hash($post['newpass'], PASSWORD_DEFAULT);
                 db_query(
                     "UPDATE $accounts
                     SET password = '$newPass'

--- a/modules/switch.php
+++ b/modules/switch.php
@@ -79,21 +79,34 @@ function switch_run()
             break;
         case 'verify':
             $post = httpallpost();
-            $post['password'] = md5(md5($post['password']));
             $post['login'] = filter_var($post['login'], FILTER_SANITIZE_STRING);
             $sql = db_query(
-                "SELECT acctid, name, uniqueid, lastip
+                "SELECT acctid, name, uniqueid, lastip, password
                 FROM $accounts
-                WHERE password = '{$post['password']}'
-                AND login = '{$post['login']}'"
+                WHERE login = '{$post['login']}'"
             );
+            $row = db_fetch_assoc($sql);
+            $valid = false;
+            if ($row) {
+                $stored = $row['password'];
+                if (substr($stored,0,1)==='$') {
+                    $valid = password_verify($post['password'], $stored);
+                } else {
+                    if (md5(md5($post['password'])) == $stored) {
+                        $valid = true;
+                    }
+                }
+            }
             if (db_num_rows($sql) == 0) {
                 addnav('Go back', 'runmodule.php?module=switch&op=add');
                 output("`\$Sorry, no account was found with those credentials!");
                 break;
             }
-            else {
-                $row = db_fetch_assoc($sql);
+            if (!$valid) {
+                addnav('Go back', 'runmodule.php?module=switch&op=add');
+                output("`\$Sorry, no account was found with those credentials!");
+                break;
+            } else {
                 addnav('Go back', 'runmodule.php?module=switch');
                 if ($row['acctid'] == $session['user']['acctid']) {
                     output("`\$Sorry, but you cannot add a link to yourself!");

--- a/prefs.php
+++ b/prefs.php
@@ -69,12 +69,7 @@ if ($op=="suicide" && getsetting("selfdelete",0)!=0) {
         }else{
             if ($pass1!=""){
                 if (strlen($pass1)>3){
-                    if (substr($pass1,0,5)!="!md5!"){
-                        $pass1 = md5(md5($pass1));
-                    }else{
-                        $pass1 = md5(substr($pass1,5));
-                    }
-                    $session['user']['password']=$pass1;
+                    $session['user']['password']=password_hash($pass1, PASSWORD_DEFAULT);
                     output("`#Your password has been changed.`n");
                 }else{
                     output("`#Your password is too short.");
@@ -172,29 +167,6 @@ if ($op=="suicide" && getsetting("selfdelete",0)!=0) {
         "bio"=>"Short Character Biography (255 chars max),string,255",
         "nojump"=>"Don't jump to comment areas after refreshing or posting a comment?,bool",
     );
-    rawoutput("<script language='JavaScript' src='lib/md5.js'></script>");
-    $warn = translate_inline("Your password is too short.  It must be at least 4 characters long.");
-    rawoutput("<script language='JavaScript'>
-    <!--
-    function md5pass(){
-        //encode passwords before submission to protect them even from network sniffing attacks.
-        var passbox = document.getElementById('pass1');
-        if (passbox.value.len < 4 && passbox.value.len > 0){
-            alert('$warn');
-            return false;
-        }else{
-            var passbox2 = document.getElementById('pass2');
-            if (passbox2.value.substring(0, 5) != '!md5!') {
-                passbox2.value = '!md5!' + hex_md5(passbox2.value);
-            }
-            if (passbox.value.substring(0, 5) != '!md5!') {
-                passbox.value = '!md5!' + hex_md5(passbox.value);
-            }
-            return true;
-        }
-    }
-    //-->
-    </script>");
     //
     $prefs = $session['user']['prefs'];
     $prefs['bio'] = $session['user']['bio'];
@@ -297,7 +269,7 @@ if ($op=="suicide" && getsetting("selfdelete",0)!=0) {
     
     $form = array_merge($form, $msettings);
     $prefs = array_merge($prefs, $mdata);
-    rawoutput("<form action='prefs.php?op=save' method='POST' onSubmit='return(md5pass)'>");
+    rawoutput("<form action='prefs.php?op=save' method='POST' >");
     $info = showform($form,$prefs);
     rawoutput("<input type='hidden' value=\"" .
             htmlentities(serialize($info), ENT_COMPAT, getsetting("charset", "ISO-8859-1"))."\" name='oldvalues'>");


### PR DESCRIPTION
## Summary
- migrate password storage from MD5 to `password_hash`
- verify logins with `password_verify` and upgrade old hashes
- remove client-side MD5 password hashing
- update admin/installer password logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68487e80e0788332aa6d8f8cbe1e4a78